### PR TITLE
Differentiate between development and runtime dependencies in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,31 +4,34 @@ PATH
     win32screenshot (1.0.6)
       ffi (~> 1.0)
       mini_magick (~> 3.2.1)
-      rake (= 0.8.7)
       rautomation (~> 0.6.3)
-      rspec (~> 2.5)
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.3)
-    ffi (1.0.9-x86-mingw32)
+    ffi (1.0.11)
     mini_magick (3.2.1)
       subexec (~> 0.0.4)
     rake (0.8.7)
     rautomation (0.6.3)
-    rspec (2.6.0)
-      rspec-core (~> 2.6.0)
-      rspec-expectations (~> 2.6.0)
-      rspec-mocks (~> 2.6.0)
-    rspec-core (2.6.4)
-    rspec-expectations (2.6.0)
+    rspec (2.8.0)
+      rspec-core (~> 2.8.0)
+      rspec-expectations (~> 2.8.0)
+      rspec-mocks (~> 2.8.0)
+    rspec-core (2.8.0)
+    rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
-    rspec-mocks (2.6.0)
+    rspec-mocks (2.8.0)
     subexec (0.0.4)
+    yard (0.7.5)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES
+  rake (= 0.8.7)
+  rspec (~> 2.5)
   win32screenshot!
+  yard

--- a/win32screenshot.gemspec
+++ b/win32screenshot.gemspec
@@ -13,10 +13,11 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
-  
-  s.add_dependency("rake", "0.8.7")
+
   s.add_dependency("ffi", "~> 1.0")
   s.add_dependency("mini_magick", "~> 3.2.1")
   s.add_dependency("rautomation", "~> 0.6.3")
-  s.add_dependency("rspec", "~> 2.5")
+  s.add_development_dependency("rake", ">=0.8.7")
+  s.add_development_dependency("rspec", "~> 2.5")
+  s.add_development_dependency("yard","~>0.7.5")
 end


### PR DESCRIPTION
Properly separate development dependencies from the actual library dependencies to avoid conflicts with rake (the rake version was locked to 0.8.7 which is quite outdated).

Fixes issue [#12](https://github.com/jarmo/win32screenshot/issues/12)
