### PR TITLE
Fix: 'File.exists?' don't work on Ruby 3.2

### DIFF
--- a/lib/win32/screenshot/image.rb
+++ b/lib/win32/screenshot/image.rb
@@ -26,7 +26,7 @@ module Win32
       # @raise [RuntimeError] when _file_path_ already exists.
       # @raise [RuntimeError] when _file_path_ is not with the supported output {FORMATS} extension.
       def write(file_path)
-        raise "File already exists: #{file_path}!" if File.exists? file_path
+        raise "File already exists: #{file_path}!" if File.exist? file_path
         write! file_path
       end
       

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ module SpecHelper
                   [:long, :long, :int, :int, :int, :int, :int], :bool
   
   def save_and_verify_image(img, file=nil)
-    FileUtils.mkdir @temp_dir unless File.exists?(@temp_dir)
+    FileUtils.mkdir @temp_dir unless File.exist?(@temp_dir)
     file_name = File.join @temp_dir, "#{file}.bmp"
     img.write file_name
     expect(img.bitmap[0..1]).to eq('BM')


### PR DESCRIPTION
'File.exists?' don't work on Ruby 3.2. So change to 'File.exist?' in image.rb