### PR TITLE
bump rautomation version requirement

### DIFF
--- a/win32screenshot.gemspec
+++ b/win32screenshot.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   
   s.add_dependency("ffi", "~> 1.15.0")
   s.add_dependency("mini_magick", "~> 4.9")
-  s.add_dependency("rautomation", "~> 2.1")
+  s.add_dependency("rautomation", "~> 2.0")
   
   s.add_development_dependency("rspec", "~> 3.10")
   s.add_development_dependency("yard")

--- a/win32screenshot.gemspec
+++ b/win32screenshot.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   
   s.add_dependency("ffi", "~> 1.15.0")
   s.add_dependency("mini_magick", "~> 4.9")
-  s.add_dependency("rautomation", "~> 1.1.0")
+  s.add_dependency("rautomation", "~> 2.1")
   
   s.add_development_dependency("rspec", "~> 3.10")
   s.add_development_dependency("yard")


### PR DESCRIPTION
The latest version of win32screenshot does not have rautomation 2.x as a dependency.

I wasn't sure if you wanted to roll on the patch number (eg \~> 2.1.0) or minor (~> 2.1), feel free to change it to what you prefer.